### PR TITLE
Fix spec to call a method twice

### DIFF
--- a/spec/mem_spec.rb
+++ b/spec/mem_spec.rb
@@ -24,6 +24,7 @@ describe Mem do
     it "memoizes the result of specified method call" do
       expect(object).to receive(:bar).once.and_call_original
       expect(object.foo { "foo" }).to eq "foo"
+      expect(object.foo { "baz" }).to eq "foo"
     end
   end
 end


### PR DESCRIPTION
To make sure that a method is memoized, I think the method should be called twice under conditions where it normally returns a different value.

Otherwise, we can't know if the result is memoized or the original method is invoked every time.
