### PR TITLE
Add support for removing memoization

### DIFF
--- a/lib/mem.rb
+++ b/lib/mem.rb
@@ -21,6 +21,10 @@ module Mem
     @memoized_table ||= {}
   end
 
+  def unmemoize(key)
+    memoized_table.delete(key)
+  end
+
   module ClassMethods
     def memoize(method_name)
       define_method("#{method_name}_with_memoize") do |*args, &block|
@@ -32,6 +36,10 @@ module Mem
       end
       alias_method "#{method_name}_without_memoize", method_name
       alias_method method_name, "#{method_name}_with_memoize"
+
+      define_method("unmemoize_#{method_name}") do
+        unmemoize(method_name)
+      end
 
       define_method("#{method_name}=") do |value|
         memoize(method_name, value)


### PR DESCRIPTION
In my case, i have a `settings` method, which is a composite of several methods from related objects. So in order to use the current schema for updating the memoized value, I need to duplicate the code in the method, in order to call `settings=` to update the value in the memoized table.

This patch allows for unsetting the value and key in the memoized table, which means that the method is it self responsible for recalculating its value the next time it's called. 
