### PR TITLE
Keep method visibility

### DIFF
--- a/lib/mem.rb
+++ b/lib/mem.rb
@@ -27,6 +27,16 @@ module Mem
 
   module ClassMethods
     def memoize(method_name)
+      original_visibility =
+        case
+        when protected_instance_methods.include?(method_name)
+          :protected
+        when private_instance_methods.include?(method_name)
+          :private
+        else
+          :public
+        end
+
       define_method("#{method_name}_with_memoize") do |*args, &block|
         if has_memoized?(method_name)
           memoized(method_name)
@@ -34,15 +44,21 @@ module Mem
           memoize(method_name, send("#{method_name}_without_memoize", *args, &block))
         end
       end
+      send(original_visibility, "#{method_name}_with_memoize")
+
       alias_method "#{method_name}_without_memoize", method_name
       alias_method method_name, "#{method_name}_with_memoize"
 
       define_method("unmemoize_#{method_name}") do
         unmemoize(method_name)
       end
+      send(original_visibility, "unmemoize_#{method_name}")
 
-      define_method("#{method_name}=") do |value|
-        memoize(method_name, value)
+      if original_visibility != :private
+        define_method("#{method_name}=") do |value|
+          memoize(method_name, value)
+        end
+        send(original_visibility, "#{method_name}=")
       end
     end
   end

--- a/spec/mem_spec.rb
+++ b/spec/mem_spec.rb
@@ -65,5 +65,41 @@ describe Mem do
         object.memoized_table.should == { a!: [1, 2] }
       end
     end
+
+    context "with non-public method name" do
+      let(:klass) do
+        Class.new do
+          include Mem
+
+          def a
+          end
+          memoize :a
+
+          protected
+
+          def b
+          end
+          memoize :b
+
+          private
+
+          def c
+          end
+          memoize :c
+        end
+      end
+
+      it 'keeps method visibilities' do
+        expect(klass.public_instance_methods).to include(:a)
+        expect(klass.protected_instance_methods).to include(:b)
+        expect(klass.private_instance_methods).to include(:c)
+      end
+
+      it 'does not define setter of private method' do
+        expect(klass.instance_methods).to include(:a=)
+        expect(klass.instance_methods).to include(:b=)
+        expect(klass.instance_methods).not_to include(:c=)
+      end
+    end
   end
 end


### PR DESCRIPTION
The current implementation makes protected or private methods to be public.
This change makes Mem to keep method visibility.
